### PR TITLE
fix #40: httpsys crashes node.exe when serving static files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ _ReSharper*
 node.exe
 httpsys.node
 msvcr110.dll
+
+test/_dummy

--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -348,8 +348,18 @@ Socket.prototype._on_written = function () {
         }
     }
 
-    if (!this._closed && this._requestContext.chunks)
-        this._initiate_send_next();
+    if (!this._closed && this._requestContext.chunks) {
+        // fix #40: httpsys native module has a problem in processing empty list of chunks,
+        //          which happens when stream gets to an end, and .write(null, null, true)
+        //          is issued to indicate it. The problem has to do with callback recursion,
+        //          and so we get out of it by scheduling _initiate_send_next() to occur on
+        //          next nodejs event-loop iteration.
+
+        if (!this._requestContext.chunks.length)
+            process.nextTick(this._initiate_send_next.bind(this));
+        else
+            this._initiate_send_next();
+    }
 };
 
 Socket.prototype._initiate_send_next = function () {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "mocha": "1.8.1",
     "ws": "0.4.27",
     "socket.io": "0.9.16",
-    "socket.io-client": "0.9.16"
+    "socket.io-client": "0.9.16",
+    "connect": "~2.12.0"
   },
   "homepage": "https://github.com/tjanczuk/httpsys",
   "repository": {

--- a/test/110_static.js
+++ b/test/110_static.js
@@ -1,0 +1,69 @@
+require('../lib/httpsys').slipstream();
+
+var http = require('http')
+    , assert = require('assert')
+    , connect = require('connect')
+    , fs = require('fs');
+
+var port = process.env.PORT || 3103;
+var server;
+
+describe('110_static.js: static', function () {
+
+    afterEach(function (done) {
+        if (server) {
+            server.close(function () {
+                done();
+                server = undefined;
+            });
+        }
+        else {
+            done();
+        }
+    });
+
+    it('works', function () {
+        assert.equal(typeof http.httpsys_version, 'string');
+    });
+
+    it('serve static file works', function (done) {
+        // Create a random file, about 35KB will do
+        var buf = new Buffer(35 * 1024);
+        buf.fill("t");
+        var fd = fs.openSync(__dirname + '/_dummy', 'w');
+        fs.writeSync(fd, buf, 0, buf.length);
+        fs.close(fd);
+    
+        // Setup server to serve static files from
+        // the folder (i.e. the _dummy file we just created)
+        server = http.createServer(connect()
+            .use(connect.static(__dirname)));
+            
+        server.on('close', function() {
+            fs.unlinkSync(__dirname + '/_dummy');
+        });
+
+        server.listen(port);
+
+        var request = http.request({
+            hostname: 'localhost',
+            port: port,
+            path: '/_dummy',
+            method: 'GET'
+        }, function (res) {
+            // Check that we could retrieve the file
+            assert.equal(res.statusCode, 200);
+            assert.equal(res.headers['content-type'], 'application/octet-stream');
+            var body = '';
+            res.on('data', function (chunk) { body += chunk; });
+            res.on('end', function () {
+                assert.ok(body.indexOf('tttttttttttttt') >= 0, "Unexpected response file contents");
+                done();
+            });
+        });
+
+        request.on('error', assert.ifError);
+        request.end();
+    });
+
+});


### PR DESCRIPTION
Fixing an issue where httpsys native module crashes node.exe process with
Access Violation 0xc0000005, when responding to a request for a static
file (or any large response).

Also adding a unit test which replicates the issue, and tests that it is fixed.
